### PR TITLE
Keep local scratch files out of the build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,10 @@
 ^\.travis\.yml$
 ^appveyor\.yml$
 ^\.github$
+^\.claude$
+^\.jules$
+^\.cursor$
+^\.windsurf$
+^\.aider\..*$
+^CLAUDE\.md$
+^blupf90_all\.pdf$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,8 +9,9 @@
 ^\.github$
 ^\.claude$
 ^\.jules$
-^\.cursor$
+^\.cursor.*$
 ^\.windsurf$
 ^\.aider\..*$
 ^CLAUDE\.md$
+^.*\.local\.md$
 ^blupf90_all\.pdf$


### PR DESCRIPTION
`R CMD build` tars the working directory, not the git index. A file that git ignores still ships in the tarball if it sits in the project root. This adds eight patterns to `.Rbuildignore` so local scratch files stay out of builds run from a working copy: the BLUPF90 manual (`blupf90_all.pdf`), editor and assistant working directories, one local notes file, and any `*.local.md` notes file.

## Why

Four of the excluded files exist in the maintainer's working copy today: the 1.8 MB manual, two tool working directories and the notes file. All are ignored by `.gitignore` or `.git/info/exclude`, and none are in `.Rbuildignore` on `main`.

Measured when the commit was written (2026-08-17):

- The manual was 27% of the tarball. Excluding all four took it from 6.7 MB to 4.8 MB.
- It cleared R CMD check's "checking for hidden files and directories" NOTE.
- A git worktree nested in one of those directories was being tarred as a second full copy of the package, with a non-portable path length warning for every file in it.

The other patterns cover working files from editors that are not in use here. They cost nothing.

The second commit follows review. `.gitignore` uses wildcards for one editor's files and for `*.local.md`, but the first commit matched only exact names. One pattern is now a prefix match, and `^.*\.local\.md$` matches at any depth, as the `.gitignore` entry does.

## Checks

The patterns were applied the way `R CMD build` applies them (case-insensitive Perl regexes on root-relative paths) to every tracked file. `main` and this branch exclude the same three tracked files, so nothing a clean checkout ships changes. Sample paths confirm the new rules catch what they should and leave `R/`, `vignettes/`, `inst/doc/`, `README.md`, `NEWS` and `DESCRIPTION` alone.

## Scope

One file, eight added lines. A clean checkout (CI included) has none of these files, so its builds do not change. The branch is based on `33efb5a` and merges into current `main` without conflicts.
