### PR TITLE
Refuse an AR grid for a non-local fit before checking for binaries

### DIFF
--- a/R/remlf90-class.R
+++ b/R/remlf90-class.R
@@ -574,7 +574,7 @@ remlf90 <- function(fixed,
 
     ## A grid is N fits, not one: a single log would be overwritten once
     ## per rho, and a single checkpoint would seed every rho alike. Keyed
-    ## on the grid rather than on `parallel`, which is inert outside here.
+    ## on the grid rather than on `parallel`, which is inert outside a grid.
     if (!is.null(progress_file) || isTRUE(cont))
       stop("'progress_file' and 'cont' are not supported for an AR rho ",
            "grid search, which fits one model per rho.\n",

--- a/R/remlf90-class.R
+++ b/R/remlf90-class.R
@@ -536,10 +536,6 @@ remlf90 <- function(fixed,
   ## the backend installed.
   progress_file <- check_progress_args(progress_file, cont, breedR.bin, debug)
 
-  if (!check_progsf90(quiet = debug | !interactive())) {
-    stop('Binary dependencies missing. See ?install_progsf90')
-  }
-
   ### Parse arguments
   method <- tolower(method)
   method <- match.arg(method)
@@ -568,35 +564,47 @@ remlf90 <- function(fixed,
     spatial <- do.call('check_spatial', 
                        c(spatial, list(data = data,
                                        response = responsem)))
-    
-    # If AR model without rho specified
-    # we need to fit it with several fixed rho's
-    # and return the most likely
+  }
+
+  ## An AR model with rho unspecified, or given as a grid, is fitted once per
+  ## rho and the most likely fit returned (below). These refusals need the
+  ## grid check_spatial() resolved, but not the binaries.
+  if (!is.null(spatial) && spatial$model == 'AR' &&
+      !is.null(nrow(spatial$rho))) {
+
+    ## A grid is N fits, not one: a single log would be overwritten once
+    ## per rho, and a single checkpoint would seed every rho alike. Keyed
+    ## on the grid rather than on `parallel`, which is inert outside here.
+    if (!is.null(progress_file) || isTRUE(cont))
+      stop("'progress_file' and 'cont' are not supported for an AR rho ",
+           "grid search, which fits one model per rho.\n",
+           " Fix rho to a single pair and re-run.", call. = FALSE)
+
+    ## A grid ranks its rhos by likelihood, and a submitted fit returns a
+    ## job id rather than a likelihood, so there is nothing here to rank.
+    ## The parallel path also builds the binary's path out of breedR.bin,
+    ## which is the literal string "submit" in this case. Neither failure
+    ## names its cause, so refuse the combination while it can still be
+    ## explained.
+    if (tolower(breedR.bin) %in% c("remote", "submit"))
+      stop("An AR rho grid search requires a local fit; it is not ",
+           "available with breedR.bin = '", breedR.bin, "'.\n",
+           " Fix rho to a single pair and re-run.", call. = FALSE)
+  }
+
+  ## After every argument check above, so that they are reachable without the
+  ## backend installed.
+  if (!check_progsf90(quiet = debug | !interactive())) {
+    stop('Binary dependencies missing. See ?install_progsf90')
+  }
+
+  if (!is.null(spatial)) {
     if( spatial$model == 'AR' ) {
 
       if (!is.null(nrow(spatial$rho))) {
         ## grid case
         ## Each rho combination is independent — fit with tryCatch so one
         ## failure doesn't kill the entire search.
-
-        ## A grid is N fits, not one: a single log would be overwritten once
-        ## per rho, and a single checkpoint would seed every rho alike. Keyed
-        ## on the grid rather than on `parallel`, which is inert outside here.
-        if (!is.null(progress_file) || isTRUE(cont))
-          stop("'progress_file' and 'cont' are not supported for an AR rho ",
-               "grid search, which fits one model per rho.\n",
-               " Fix rho to a single pair and re-run.", call. = FALSE)
-
-        ## A grid ranks its rhos by likelihood, and a submitted fit returns a
-        ## job id rather than a likelihood, so there is nothing here to rank.
-        ## The parallel path also builds the binary's path out of breedR.bin,
-        ## which is the literal string "submit" in this case. Neither failure
-        ## names its cause, so refuse the combination while it can still be
-        ## explained.
-        if (tolower(breedR.bin) %in% c("remote", "submit"))
-          stop("An AR rho grid search requires a local fit; it is not ",
-               "available with breedR.bin = '", breedR.bin, "'.\n",
-               " Fix rho to a single pair and re-run.", call. = FALSE)
 
         n_rho <- nrow(spatial$rho)
 

--- a/tests/testthat/test-AR.R
+++ b/tests/testthat/test-AR.R
@@ -45,12 +45,24 @@ context("AR rho grid search")
 
 test_that("an AR rho grid is refused for a non-local fit", {
 
-  grid_fit <- function(bin)
+  ## Hide the backend, as CI installs without it, so that the claim above is
+  ## tested wherever this runs and not only on machines that lack it.
+  no_bin <- tempfile("no_progsf90_")
+  dir.create(no_bin)
+  old_bin <- breedR.getOption("breedR.bin")
+  breedR.setOption("breedR.bin", no_bin)
+  on.exit({
+    breedR.setOption("breedR.bin", old_bin)
+    unlink(no_bin, recursive = TRUE)
+  }, add = TRUE)
+  expect_false(check_progsf90(quiet = TRUE))
+
+  grid_fit <- function(bin, ...)
     remlf90(fixed = phe_X ~ gg, data = globulus,
             spatial = list(model = 'AR',
                            coord = globulus[, c('x', 'y')],
                            rho = rbind(c(.8, .8), c(.9, .9))),
-            breedR.bin = bin)
+            breedR.bin = bin, ...)
 
   ## A submitted fit returns a job id rather than a likelihood, so the grid has
   ## no way to rank its rhos. It used to get as far as building a binary path
@@ -67,4 +79,9 @@ test_that("an AR rho grid is refused for a non-local fit", {
   ## The name is matched case-insensitively, as it is everywhere else it is
   ## tested (see check_progress_args()).
   expect_error(grid_fit('Submit'), "requires a local fit")
+
+  ## The log and resume refusal beside it is an argument check too.
+  expect_error(grid_fit(no_bin,
+                        progress_file = file.path(tempdir(), "grid.log")),
+               "rho grid")
 })

--- a/tests/testthat/test-AR.R
+++ b/tests/testthat/test-AR.R
@@ -84,4 +84,9 @@ test_that("an AR rho grid is refused for a non-local fit", {
   expect_error(grid_fit(no_bin,
                         progress_file = file.path(tempdir(), "grid.log")),
                "rho grid")
+
+  ## A local grid still needs the backend, and must be told so before the
+  ## per-rho fits start: each runs inside a tryCatch, which would bury the
+  ## cause under "All rho combinations failed".
+  expect_error(grid_fit(no_bin), "Binary dependencies missing")
 })


### PR DESCRIPTION
Fixes #34.

## Cause

`test-AR.R` checks that an AR rho grid with `breedR.bin = 'submit'` or `'remote'` is refused with "requires a local fit", and says this needs no binaries. In `remlf90()` the binary check ran before `check_spatial()`, and the refusal sat inside the grid branch after that. With no backend installed, the call stopped at "Binary dependencies missing" first. CI installs with `BREEDR_SKIP_INSTALL_BINARIES: true`, so all six jobs failed on these four expectations.

The fault is in the order of the checks in the R wrapper. The test and the backend are fine. The comment above `check_progress_args()` already says argument guards go before the binary check so they are reachable without the backend.

## Change

- The binary check moves below `check_spatial()`, still above the grid branch.
- The two grid refusals (non-local fit, and `progress_file`/`cont`) move out of the grid branch to run just before it. They need the grid that `check_spatial()` resolves, since an NA or missing `rho` becomes a grid there, but they don't need the binaries. Messages are unchanged.
- The grid fitting code is untouched and keeps its nesting, so the diff stays small.

With the backend installed the binary check passes silently wherever it sits, so results are identical. A two-rho globulus grid gives the same loglik table and variance components before and after.

Without the backend, invalid genetic or spatial specs, a bad `method` and the grid refusals now report their own error before "Binary dependencies missing". `check_generic()`, `check_genomic()` and `check_var.ini()` still run after the binary check, as before.

## Test

The existing test now hides the backend itself by pointing the `breedR.bin` option at an empty temp directory and restoring it on exit, with `expect_false(check_progsf90())` as a precondition. It catches both halves of the new order on any machine:

- **Refusals come first.** The grid refusals (`submit`, `remote`, `Submit`, `progress_file`) fire without a backend. Against the old ordering these failed 5 times with "Binary dependencies missing", on a machine that has the binaries.
- **The binary check still precedes the per-rho fits.** A local grid still stops at "Binary dependencies missing". Each per-rho fit runs inside a `tryCatch`, so if the check slid below the grid branch the cause would surface as "All rho combinations failed … Try specifying rho manually". With the check moved there, this assertion fails with exactly that message and the rest of the test still passes.

## Verification

- **Unit suite (1b6a2c9):** 1009 expectations, 0 failures, with the binaries visible and with them hidden.
- **Integration suite (d7e97af):** 590 expectations. The 4 failures are the ones already filed: #27, #28, and the two under #29.
- **`R CMD check --no-manual --no-vignettes` (d7e97af),** on a tarball installed with `BREEDR_SKIP_INSTALL_BINARIES=true`: tests go from `FAIL 4` to `[ FAIL 0 | WARN 1 | SKIP 2 | PASS 1014 ]`. Status is 1 WARNING and 2 NOTEs, all INLA or Rd formatting and not from this change.
- **CI on d7e97af:** `test-AR.R` passes on every job. The remaining failures are not from this PR: `test-checks.R:629-631` on both macOS jobs (#44), and `test-checkpoint.R:436` on the Ubuntu and macOS jobs, which #34 excludes.

## Merge note

The message of d7e97af says the binary check "now comes after the argument checks". More exactly, it comes after the argument checks up to and including `check_spatial()`. If this is squash-merged, the combined message can say so.

## Not included

- `check_progsf90()` checks for a local binary even for remote and submit fits, which never run one. It also reads the option rather than a `breedR.bin` path passed as an argument. This is worth its own issue.
- A matrix `rho` grid fails once the fits finish: `object 'ans.rho' not found` sequentially, `object 'loglik_vals' not found` in parallel. That is #4.
- Found during review and filed separately: #42 (`rho = c(NA, NA)` fails although the docs call it the default), #43 (double pedigree IDs printing as `1e+05` are rejected), #44 (the macOS `test-checks.R` failure).
