### PR TITLE
Assert the drained output, not that the line reader misses the tail

### DIFF
--- a/R/remlf90-class.R
+++ b/R/remlf90-class.R
@@ -1165,10 +1165,11 @@ remlf90 <- function(fixed,
         } else if (!px$is_alive()) break
       }
 
-      ## read_output_lines() returns complete lines only, so a final line with
-      ## no newline stays buffered and would be dropped. Draining after the
-      ## loop costs nothing and avoids depending on the backend always ending
-      ## its output with a newline.
+      ## read_output_lines() returns a final line with no newline only once it
+      ## has seen EOF, and that can come after the loop has left on
+      ## !is_alive() -- usually on Windows, occasionally on Unix. Draining
+      ## after the loop costs nothing and avoids depending on either that
+      ## timing or the backend always ending its output with a newline.
       ## Split on \r?\n, not \n: read_output_lines() translates CRLF but
       ## read_output() does not, so splitting on \n alone would leave a
       ## trailing \r on every drained line and make this path disagree with

--- a/tests/testthat/test-checkpoint.R
+++ b/tests/testthat/test-checkpoint.R
@@ -415,8 +415,10 @@ test_that("remlf90() guards the backend it starts", {
 
 test_that("the tail drain recovers a newline-less line", {
 
-  ## read_output_lines() returns complete lines only, so a final line with no
-  ## newline stays buffered and the loop would walk away from it.
+  ## read_output_lines() returns a final line with no newline only once it has
+  ## seen EOF. On Windows that usually comes after the loop has already left on
+  ## !is_alive(); on Unix it usually comes in time. Whichever path picks the
+  ## line up, it must end up in the output exactly once, in order.
   skip_if_not_installed("processx")
 
   rs <- file.path(R.home("bin"), "Rscript")
@@ -432,13 +434,9 @@ test_that("the tail drain recovers a newline-less line", {
     if (length(l)) out <- c(out, l) else if (!px$is_alive()) break
   }
 
-  ## the loop alone loses it
-  expect_false("no-trailing-newline" %in% out)
-
   tail_out <- px$read_output()
-  out <- c(out, strsplit(tail_out, "\r?\n")[[1]])
-  expect_true("no-trailing-newline" %in% out)
-  expect_false(any(grepl("\r", out)))
+  if (nzchar(tail_out)) out <- c(out, strsplit(tail_out, "\r?\n")[[1]])
+  expect_identical(out, c("alpha", "beta", "no-trailing-newline"))
 })
 
 


### PR DESCRIPTION
Fixes #45.

`test-checkpoint.R:436` asserted that the polling loop copied from `remlf90()` never picks up a final line with no newline. That is a property of when processx sees EOF, not of breedR:

- `processx__connection_find_lines()` returns a trailing partial line once `is_eof_raw_` is set. On Unix, `read()` returning 0 sets it synchronously, so the loop usually gets the line and the precondition failed on every Ubuntu and macOS job.
- On Windows, EOF comes through an overlapped read and usually lands after the loop has left on `!is_alive()`. Usually, not always: the loop caught the line in 1 of 220 local runs (processx 3.8.6), so a Windows-only version of the check would be flaky.

The test now asserts what holds everywhere: loop plus drain return `c("alpha", "beta", "no-trailing-newline")`, in order, each line once. That covers the old presence and no-`\r` checks and also catches duplication. The drain mirrors `remlf90()`'s `nzchar()` guard. The production comment at `R/remlf90-class.R:1168` no longer states the Windows behaviour as universal. No code change in `remlf90()`.

Checked on Windows:

- `test-checkpoint.R` passes. With the drain removed from the test's copy of the loop, the new assertion fails.
- Unit suite: 1007 pass, 0 fail.
- `R CMD check --no-build-vignettes` with `BREEDR_SKIP_INSTALL_BINARIES=true`: `[ FAIL 0 | WARN 1 | SKIP 2 | PASS 1013 ]`, 1 WARNING and 2 NOTEs (the known INLA and `.Rd` ones). Two fewer expectations than `main`, because three assertions became one.

The Unix side can only be confirmed by CI. #44 can still fail the macOS jobs independently.
