### PR TITLE
Compare default_initial_variance() to half the variance with a tolerance

### DIFF
--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -626,9 +626,9 @@ test_that('default_initial_variance() works as expected', {
   ## One trait: always return half the phenotypic variance
   x <- runif(100)
   
-  expect_identical(as.matrix(var(x)/2), default_initial_variance(x))
-  expect_identical(as.matrix(var(x)/2), default_initial_variance(x, cor.trait = 0))
-  expect_identical(as.matrix(var(x)/2), default_initial_variance(x, cor.effect = 0))
+  expect_equal(as.matrix(var(x)/2), default_initial_variance(x))
+  expect_equal(as.matrix(var(x)/2), default_initial_variance(x, cor.trait = 0))
+  expect_equal(as.matrix(var(x)/2), default_initial_variance(x, cor.effect = 0))
   
   ## One trait - 2 dimensional effect (e.g. competition)
   x <- runif(100)


### PR DESCRIPTION
Fixes #44.

`test-checks.R:629-631` compared `as.matrix(var(x)/2)` with `default_initial_variance(x)` using `expect_identical()`. The function computes `var(as.matrix(x), na.rm = TRUE)/2`, a different call from the test's `var(x)`. On macOS arm64 the two can differ in the last bit, so these lines failed on some random draws. The draw is unseeded, which makes the failure intermittent: run 34541934130 failed on both macOS jobs, and run 34545018715 failed on `macos-latest (release)` only.

Nothing after the variance can differ for these three lines. The 1x1 exchangeable matrix is exactly 1 (`0.1 + 0.9` and `0 + 1`), `kronecker()` multiplies by it, and `digits` is NULL. So this is a test problem. `default_initial_variance()` is unchanged.

The change swaps `expect_identical()` for `expect_equal()` on those three lines. The package is on testthat edition 2, where `expect_equal()` uses `all.equal()` (relative tolerance about 1.5e-8) and still compares attributes, so the check that the result is a 1x1 matrix stays. The rest of the same test block already uses `expect_equal()`.

## Checks

Run locally on Windows, R 4.5.2, after `load_all()`:

- A one-ulp difference on a 1x1 matrix passes `expect_equal()`; a dropped `dim` fails it.
- The new assertion still fails for an un-halved variance and for a 1e-6 relative error.
- `test-checks.R`: 0 failed, 139 passed.
- Full unit suite: 0 failed, 1005 passed, with the known skip (`test-renderpf90.R:32`) and warning (`test-renumf90-from-data.R:69`).

The macOS mismatch can't be reproduced on Windows, so a green macOS run here only shows the draw didn't trip it. The tolerance is what makes the fix hold.
