### PR TITLE
Label pedigrees built from double codes without scientific notation

### DIFF
--- a/R/pedigree.R
+++ b/R/pedigree.R
@@ -100,7 +100,11 @@ build_pedigree <- function(x, self = x[[1]], sire = x[[2]], dam = x[[3]], data) 
   # pedx should pass all checks
   stopifnot(all(check_pedigree(pedx)))
 
-  out <- pedigreemm::pedigree(sire = pedx$sire, dam = pedx$dam, label = pedx$self)
+  # Integer codes: pedigreemm stores labels with as.character(), which would
+  # write a double 100000 as "1e+05" and no id would match it.
+  out <- pedigreemm::pedigree(sire  = as.integer(pedx$sire),
+                              dam   = as.integer(pedx$dam),
+                              label = as.integer(pedx$self))
   if( !all(checks)) attr(out, 'map') <- map
   return(out)
 }

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -99,6 +99,23 @@ test_that("check_genetic() returns an error if pedigree is not of class pedigree
                'argument pedigree')
 })
 
+test_that("check_genetic() accepts double ids that print in scientific notation (#43)", {
+  ## A pedigree already coded 1..n is not recoded, so the ids are matched
+  ## against its labels directly. 100000 as a double used to be labelled
+  ## "1e+05" and rejected as missing from the pedigree.
+  ped_dbl <- data.frame(self = as.numeric(seq_len(1e5)), dad = 0, mum = 0)
+  dat_dbl <- data.frame(id = c(1, 99999, 1e5), y = c(0.3, -1.2, 0.8))
+
+  spec <- check_genetic(model = 'add_animal',
+                        pedigree = ped_dbl,
+                        id = 'id',
+                        data = dat_dbl,
+                        response = dat_dbl$y)
+
+  expect_identical(spec$id, c(1L, 99999L, 100000L))
+  expect_identical(spec$pedigree@label[spec$id], c('1', '99999', '100000'))
+})
+
 ## Model competition ##
 coordinates <- matrix(c(1,2,-1,0,0,1,-1,1),4,2)
 var.ini.mat <- matrix(c(1, -.5, -.5, 1), 2, 2)

--- a/tests/testthat/test-genomic-helpers.R
+++ b/tests/testthat/test-genomic-helpers.R
@@ -276,6 +276,26 @@ test_that("stage_input() does not write through the link into sibling directorie
 })
 
 
+## -- write_xref_from_pedigree() --
+
+test_that("write_xref_from_pedigree() finds genotyped ids of 1e5 and above (#43)", {
+
+  ## The SNP file holds ids as text, so they are matched against the pedigree
+  ## labels as text. A double code 100000 used to be labelled "1e+05".
+  ped <- build_pedigree(1:3, data = data.frame(self = as.numeric(seq_len(1e5)),
+                                               dad = 0, mum = 0))
+  wd  <- breedR_workdir()
+  on.exit(unlink(wd, recursive = TRUE), add = TRUE)
+  snp <- file.path(wd, 'geno.txt')
+  writeLines(c('100000 0120', '5 1111'), snp)
+
+  write_xref_from_pedigree(snp, ped, wd)
+
+  expect_identical(readLines(file.path(wd, 'geno.txt_XrefID')),
+                   c('100000 100000', '5 5'))
+})
+
+
 ## -- postgsf90() input checks --
 
 ## These run without binaries: each stops before anything is executed.

--- a/tests/testthat/test-pedigree.R
+++ b/tests/testthat/test-pedigree.R
@@ -40,3 +40,28 @@ test_that('build_pedigree() fixes everything', {
   expect_true(all(check_pedigree(ped_fix)))
 })
 
+
+test_that('build_pedigree() labels double codes of 1e5 and above in full (#43)', {
+
+  ## Codes 1..n need no recoding, so the labels are the codes themselves.
+  ## pedigreemm stores labels with as.character(), which writes a double
+  ## 100000 as "1e+05", and then no integer id matches it.
+  n <- 100001
+  ped_dbl <- data.frame(self = as.numeric(seq_len(n)), dad = 0, mum = 0)
+  ped_dbl[n, c('dad', 'mum')] <- c(1e5, 5e4)
+  ped_int <- data.frame(self = seq_len(n), dad = 0L, mum = 0L)
+  ped_int[n, c('dad', 'mum')] <- c(100000L, 50000L)
+
+  ped43 <- build_pedigree(1:3, data = ped_dbl)
+
+  expect_null(attr(ped43, 'map'))
+  expect_identical(ped43@label[1e5], '100000')
+
+  ## parents still point at the right individuals
+  expect_identical(ped43@sire[n], 100000L)
+  expect_identical(ped43@dam[n], 50000L)
+
+  ## the storage type of the codes makes no difference
+  expect_identical(ped43, build_pedigree(1:3, data = ped_int))
+})
+


### PR DESCRIPTION
Closes #43.

`build_pedigree()` passed the codes to `pedigreemm::pedigree()` unchanged, and pedigreemm stores labels with `as.character()`. A double 100000 became `"1e+05"`, so:

- `check_genetic()` rejected the fit ("individuals in id are not represented in the pedigree: 100000")
- `write_xref_from_pedigree()` failed with "Genotyped animals not found in the pedigree: 100000"
- `ranef()` named that animal `"1e+05"`

The fix passes self, sire and dam as integers. Parents are converted with the labels because pedigreemm matches them to the labels with `factor()`. On a 100,001-animal pedigree, `@sire`, `@dam` and `as.data.frame()` (the pedigree file written for blupf90+) are `identical()` to before. Only `@label` changes.

This is a regression from `a7e63f2`. Before it, double codes always failed the consecutive-codes check and were recoded to integer labels.

### The example in #43 still won't fit

The issue's pedigree (`99999, 100000, 100001`) gets past the ID check now, but stops in `additive_genetic_animal()` at `max(idx) <= length(pedigree@label)`. That happens with integer IDs too. `check_pedigree()` doesn't require codes to start at 1, despite its docs, so the pedigree isn't recoded and its codes are used as positions. That's a separate defect (since `25c3b61`, always an error) and needs its own issue. The tests here use codes `1..n` with `n >= 1e5`, which is how this bug shows up in real data and stays non-recoded under either rule.

### Tests

Three unit tests, no binaries needed. Each failed before the fix for the reason above:

- `test-pedigree.R`: label `"100000"`, parent links intact, and double and integer codes build `identical()` pedigrees
- `test-checks.R`: `check_genetic()` accepts double IDs up to 1e5 and ties each one to its own label
- `test-genomic-helpers.R`: `write_xref_from_pedigree()` maps SNP ID `100000` to code 100000

### Verification

- Unit suite: 1013 pass, 0 fail (baseline 1005 plus the 8 new expectations)
- A 100,005-animal `add_animal` fit with double IDs now runs. Variances, `ranef()` values and names, `fixef()` and `fitted()` are `identical()` to the integer-ID fit.
- Integration suite: 585 pass. The only failures are the four already filed (#27, #28, #29).
- `R CMD check --no-build-vignettes`: 1 WARNING, 2 NOTEs, the same as `main` (INLA and Rd formatting)

### Not in this PR

A user-built `pedigreemm::pedigree(label = <doubles>)` passed straight to `genetic$pedigree` keeps its `"1e+05"` labels, because `check_genetic()` keeps any pedigree object that passes its checks.
