### PR TITLE
Map genotyped animals through the recode map when writing the XrefID

### DIFF
--- a/R/genomic.R
+++ b/R/genomic.R
@@ -616,13 +616,17 @@ write_xref_file <- function(renumbered_ids, original_ids, snp_file) {
 ## Derive the preGSf90 XrefID from breedR's pedigree renumbering and write it
 ## into the working directory next to the copied SNP file. Each SNP-file row's
 ## (original) animal id is mapped to its renumbered code (its position in the
-## pedigree labels). Errors if a genotyped animal is absent from the pedigree.
+## pedigree). A recoded pedigree's labels are the new codes, so they are
+## translated back to the original ones through attr(pedigree, 'map') first.
+## Errors if a genotyped animal is absent from the pedigree.
 write_xref_from_pedigree <- function(snp_file, pedigree, tmpdir) {
   raw <- readLines(snp_file)
   raw <- raw[nchar(trimws(raw)) > 0]
   snp_ids <- vapply(strsplit(trimws(raw), "[[:space:]]+"), `[`, "", 1L)
 
   labels <- as.character(pedigree@label)
+  if (!is.null(map <- attr(pedigree, 'map')))
+    labels <- as.character(match(as.integer(pedigree@label), map))
   renum <- match(snp_ids, labels)
   if (anyNA(renum))
     stop("Genotyped animals not found in the pedigree: ",

--- a/tests/integration/test-genomic.R
+++ b/tests/integration/test-genomic.R
@@ -72,6 +72,37 @@ test_that("a second fit reuses the staged genotype file", {
   expect_false(dir.exists(res.gen2$reml$dir))
 })
 
+test_that("relabelling the animals so the pedigree is recoded changes nothing (#49)", {
+
+  ## Reversing the codes puts offspring before their parents, so breedR
+  ## recodes the pedigree. The same animals, phenotypes and genotypes under
+  ## other names must give the same fit; with the genotypes attached to the
+  ## wrong animals they did not.
+  N   <- max(globulus[, c('self', 'dad', 'mum')])
+  flip <- function(x) ifelse(x == 0, 0L, as.integer(N + 1L - x))
+  glob_rev <- globulus
+  glob_rev[, c('self', 'dad', 'mum')] <-
+    lapply(globulus[, c('self', 'dad', 'mum')], flip)
+
+  rev_dir  <- breedR_workdir('recoded_')
+  on.exit(unlink(rev_dir, recursive = TRUE), add = TRUE)
+  rev_file <- file.path(rev_dir, "test_ssgblup_recoded.txt")
+  write_snp_file(Gmat, ids = flip(gen_ids), file = rev_file)
+
+  res.rev <- suppressWarnings(suppressMessages(
+    remlf90(fixed = phe_X ~ gg,
+            genetic = list(model = 'add_animal',
+                           pedigree = glob_rev[, 1:3], id = 'self'),
+            genomic = list(snp_file = rev_file, verify_parentage = 0L),
+            data = glob_rev)))
+  expect_false(is.null(attr(get_pedigree(res.rev), 'map')))
+
+  expect_equal(as.numeric(logLik(res.rev)), as.numeric(logLik(res.gen)),
+               tolerance = 1e-6)
+  expect_equal(res.rev$var, res.gen$var, tolerance = 1e-6)
+  expect_equal(fitted(res.rev), fitted(res.gen), tolerance = 1e-6)
+})
+
 test_that("a genotyped animal absent from the pedigree is an error", {
   bad_file <- file.path(tempdir(), "test_ssgblup_bad.txt")
   write_snp_file(Gmat[1:3, , drop = FALSE],

--- a/tests/integration/test-genomic.R
+++ b/tests/integration/test-genomic.R
@@ -95,12 +95,23 @@ test_that("relabelling the animals so the pedigree is recoded changes nothing (#
                            pedigree = glob_rev[, 1:3], id = 'self'),
             genomic = list(snp_file = rev_file, verify_parentage = 0L),
             data = glob_rev)))
-  expect_false(is.null(attr(get_pedigree(res.rev), 'map')))
+  map <- attr(get_pedigree(res.rev), 'map')
+  expect_false(is.null(map))
 
+  ## Relabelling leaves logLik unchanged to about 1e-11. With the genotypes
+  ## on the wrong animals it moved by a relative 1.8e-6.
   expect_equal(as.numeric(logLik(res.rev)), as.numeric(logLik(res.gen)),
-               tolerance = 1e-6)
+               tolerance = 1e-9)
   expect_equal(res.rev$var, res.gen$var, tolerance = 1e-6)
   expect_equal(fitted(res.rev), fitted(res.gen), tolerance = 1e-6)
+
+  ## Each animal's breeding value, matched by its globulus id. The recoded fit
+  ## names them by its own codes, which the map and flip() take back.
+  bv_rev <- ranef(res.rev)$genetic
+  bv_gen <- ranef(res.gen)$genetic
+  orig   <- flip(match(as.integer(names(bv_rev)), map))
+  expect_equal(as.numeric(bv_rev)[match(as.integer(names(bv_gen)), orig)],
+               as.numeric(bv_gen), tolerance = 1e-6)
 })
 
 test_that("a genotyped animal absent from the pedigree is an error", {

--- a/tests/testthat/test-genomic-helpers.R
+++ b/tests/testthat/test-genomic-helpers.R
@@ -295,6 +295,47 @@ test_that("write_xref_from_pedigree() finds genotyped ids of 1e5 and above (#43)
                    c('100000 100000', '5 5'))
 })
 
+test_that("write_xref_from_pedigree() translates ids of a recoded pedigree (#49)", {
+
+  ## Animal 1 precedes its parents 2 and 3, so the pedigree is recoded with
+  ## map 3 1 2. The SNP file holds the original ids; the XrefID must give the
+  ## recoded code that breedR writes in the pedigree and data files.
+  ped <- suppressWarnings(
+    build_pedigree(1:3, data = data.frame(self = 1:3, dad = c(2L, 0L, 0L),
+                                          mum = c(3L, 0L, 0L))))
+  expect_identical(attr(ped, 'map'), c(3L, 1L, 2L))
+  wd  <- breedR_workdir()
+  on.exit(unlink(wd, recursive = TRUE), add = TRUE)
+  snp <- file.path(wd, 'geno.txt')
+  writeLines(c('1 0120', '2 1111', '3 2222'), snp)
+
+  write_xref_from_pedigree(snp, ped, wd)
+
+  expect_identical(readLines(file.path(wd, 'geno.txt_XrefID')),
+                   c('3 1', '1 2', '2 3'))
+})
+
+test_that("write_xref_from_pedigree() rejects a recoded code given as an id (#49)", {
+
+  ## Codes with gaps are recoded 10, 20, 30 -> 1, 2, 3. An id of 2 is not an
+  ## animal of this pedigree, even though 2 is one of its recoded codes.
+  ped <- suppressWarnings(
+    build_pedigree(1:3, data = data.frame(self = c(10L, 20L, 30L),
+                                          dad = 0L, mum = 0L)))
+  wd  <- breedR_workdir()
+  on.exit(unlink(wd, recursive = TRUE), add = TRUE)
+  snp <- file.path(wd, 'geno.txt')
+
+  writeLines(c('30 0120', '10 1111'), snp)
+  write_xref_from_pedigree(snp, ped, wd)
+  expect_identical(readLines(file.path(wd, 'geno.txt_XrefID')),
+                   c('3 30', '1 10'))
+
+  writeLines(c('30 0120', '2 1111'), snp)
+  expect_error(write_xref_from_pedigree(snp, ped, wd),
+               "not found in the pedigree: 2$")
+})
+
 
 ## -- postgsf90() input checks --
 

--- a/tests/testthat/test-genomic-helpers.R
+++ b/tests/testthat/test-genomic-helpers.R
@@ -336,6 +336,25 @@ test_that("write_xref_from_pedigree() rejects a recoded code given as an id (#49
                "not found in the pedigree: 2$")
 })
 
+test_that("write_xref_from_pedigree() finds ids of 1e5 and above in a recoded pedigree (#43, #49)", {
+
+  ## Double codes with gaps are recoded. The ids translated back through the
+  ## map must print as "100000", not "1e+05", or no genotyped animal matches.
+  ped <- suppressWarnings(
+    build_pedigree(1:3, data = data.frame(self = c(1e5, 2.5e5, 300001),
+                                          dad = 0, mum = 0)))
+  expect_false(is.null(attr(ped, 'map')))
+  wd  <- breedR_workdir()
+  on.exit(unlink(wd, recursive = TRUE), add = TRUE)
+  snp <- file.path(wd, 'geno.txt')
+  writeLines(c('300001 0120', '100000 1111'), snp)
+
+  write_xref_from_pedigree(snp, ped, wd)
+
+  expect_identical(readLines(file.path(wd, 'geno.txt_XrefID')),
+                   c('3 300001', '1 100000'))
+})
+
 
 ## -- postgsf90() input checks --
 


### PR DESCRIPTION
Fixes #49.

## Problem

When `build_pedigree()` recodes a pedigree, `remlf90(genomic = ...)` wrote a preGSf90 XrefID that paired each genotyped animal with the wrong pedigree code. The fit ran without error and reported single-step results with genotypes attached to other animals.

`write_xref_from_pedigree()` matched the SNP file's original ids against `pedigree@label`. A recoded pedigree's labels are the new codes `1..n`, so every original id was read as a recoded one. The pedigree and data files breedR writes use recoded codes throughout, and the XrefID was the one place that didn't.

It affects recoded pedigrees only, meaning codes with gaps or an offspring coded below a parent. Pedigrees that keep their codes (globulus among them) and a user-supplied `<snp_file>_XrefID` are unaffected.

## Fix

Before matching, translate the labels back to original codes with `match(label, map)`, the back-transform `?build_pedigree` documents. Matching stays textual, as it was after #43, and an id that doesn't resolve still raises "Genotyped animals not found in the pedigree".

I didn't use `map[as.integer(snp_ids)]`. A zero subscript is dropped, which shortens the vector and misaligns ids with codes, and `"3.7"` would truncate to animal 3.

## Tests

- Unit tests (`test-genomic-helpers.R`, no binaries):
  - The issue's three-animal pedigree (map `3 1 2`) must give `3 1 / 1 2 / 2 3`. It gave `1 1 / 2 2 / 3 3`.
  - A pedigree with gaps (`10, 20, 30`) must translate `30` and `10`, and must reject `2`. Before the fix, `2` silently took animal 20's code.
  - A recoded pedigree with double codes of 1e5 and above (where #43 and #49 overlap): translated ids must print as `100000`, not `1e+05`.
- Integration test (`test-genomic.R`): refits the globulus ssGBLUP model with every code reversed, which forces recoding. It requires the same logLik (relative tolerance 1e-9), variance components, fitted values and per-animal breeding values, matched by globulus id, as the original fit. Against the old function all four fail. The genetic variance comes out at 3.27 instead of 3.40, all 1021 fitted values differ and all 1089 breeding values differ.

## Verification

- Unit suite: 1017 pass, 0 fail at the first commit (1013 on `main`, plus the 4 new expectations). The second commit adds 2 more expectations to `test-genomic-helpers.R`, which passes.
- Integration suite, compared per file against `main` at `31b8f28`: identical except `test-genomic.R` (+4 at the first commit, +5 now) and `test-reml-checkpoint.R`, whose timed polling block varies from run to run. The four known failures (#27, #28, #29 x2) are unchanged.
- `R CMD check --no-vignettes` with `BREEDR_SKIP_INSTALL_BINARIES=true`: 1 WARNING and 2 NOTEs, the same INLA and Rd items as on `main`. Tests OK.

No change to the API, object structure or parsed output. Estimates change only for genomic fits on recoded pedigrees, which were wrong.

#50 (`check_pedigree()` not requiring codes to start at 1) should follow this one, since fixing it sends more pedigrees through recoding.
